### PR TITLE
Small README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # kotlinx-datetime-ext
 **A Kotlin Multiplatform library that provides `kotlinx-datetime` extensions and helper functions.**
 
-If you've recently switched from **`java.time`** APIs to **`kotlinx-datetime`**, you've probably noticed that it's missing a lot of functionality that has to be implemented manually. This library comes to close the gap by providing most of **java.time**'s functionalities but in Kotlin!
+If you've recently switched from **`java.time`** APIs to **`kotlinx-datetime`**, you've probably noticed that it's missing a lot of functionality that has to be implemented manually. This library comes to close the gap by providing most of `java.time`'s functionalities but in Kotlin!
 
 
 ### Supported platforms

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Kotlin](https://img.shields.io/badge/kotlin-1.9.21-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![Kotlinx-DateTime](https://img.shields.io/badge/kotlinx--datetime-0.5.0-blue)](https://github.com/Kotlin/kotlinx-datetime)
 # kotlinx-datetime-ext
-A Kotling Multiplatform library that provides for kotlinx-datetime extensions and helper functions
+**A Kotlin Multiplatform library that provides `kotlinx-datetime` extensions and helper functions.**
 
-If you recently switched from **java.datetime** to **kotlinx.datetime** you probably noticed that its missing a lot of functionality that you will have to do manually, this library comes to close the gap by providing most of the **java.datetime** functionality but in Kotlin!
+If you've recently switched from **`java.time`** APIs to **`kotlinx-datetime`**, you've probably noticed that it's missing a lot of functionality that has to be implemented manually. This library comes to close the gap by providing most of **java.time**'s functionalities but in Kotlin!
 
 
 ### Supported platforms
@@ -17,7 +17,7 @@ If you recently switched from **java.datetime** to **kotlinx.datetime** you prob
 ```kt
 implementation("com.raedghazal:kotlinx_datetime_ext:1.1.0")
 ```
-if you're using it in commonMain and would like to access it from androidApp then use `api(...)` instead to expose it [more about the difference between implementation and api](https://stackoverflow.com/a/44419574/10834775)
+If you're using it in `commonMain` and want to access it from `androidApp`, then use `api(...)` instead to expose it. [More about the difference between `implementation` and `api`](https://stackoverflow.com/a/44419574/10834775).
 
 
 
@@ -25,8 +25,8 @@ if you're using it in commonMain and would like to access it from androidApp the
 
 
 ### 1. Math
-To add or subtract date or time to `LocalDateTime` object
-you can use operator functions `+` and `-` with duration values
+Add or subtract date or time to a `LocalDateTime`
+using operator functions `+` and `-` with duration values:
 ```kt
 val localDateTime = LocalDateTime(2023, 1, 7, 21, 0)
 
@@ -34,7 +34,7 @@ val afterFiveDays = localDateTime + 5.days
 val beforeThreeHours = localDateTime - 3.hours
 ```
 
-or using the overload function with DateTimeUnit
+Or using the `DateTimeUnit` overload:
 ```kt
 val localDateTime = LocalDateTime(2023, 1, 7, 21, 0)
 
@@ -51,7 +51,7 @@ val formatter = LocalDateTimeFormatter.ofPattern("dd/MM/yyyy - HH:mm", Locale.en
 
 print(formatter.format(localDateTime)) //"01/01/2023 - 01:01"
 ```
-the overloads support all datetime objects
+There are overloads for all date/time objects:
 ```kt
 fun format(localDateTime: LocalDateTime): String
 fun format(localTime: LocalTime): String
@@ -59,47 +59,47 @@ fun format(localDate: LocalDate): String
 ```
 
 #### Parsing from String
-```
+```kt
 val formatter = LocalDateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.en())
 val localDateTime = formatter.parseToLocalDateTime("2023-01-01 01:01:00") // LocalDateTime(2023, 1, 1, 1, 1)
 ```
-also you can parse to any datetime object
+You can also parse to any date/time object
 ```kt
-    fun parseToLocalDateTime(str: String): LocalDateTime
-    fun parseToLocalDate(str: String): LocalDate
-    fun parseToLocalTime(str: String): LocalTime
+fun parseToLocalDateTime(str: String): LocalDateTime
+fun parseToLocalDate(str: String): LocalDate
+fun parseToLocalTime(str: String): LocalTime
 ```
 
 ### Helper extension functions
 
-To transform a LocalDate object to LocalDateTime you can use `atStartOfDay()` or `atEndOfDay()` similar to **java.datetime**
-
+Transform a `LocalDate` to a `LocalDateTime`, you can use `atStartOfDay()` or `atEndOfDay()`, similar to **java.time**:
 ```kt
 val localDate = LocalDate(2023, 12, 17).atStartOfDay() //LocalDateTime(2023, 12, 17, 0, 0)
 val localDate = LocalDate(2023, 12, 17).atEndOfDay() // LocalDateTime(2023, 12, 17, 23, 59, 59, 999999999)
 ```
 
-To get the **min time**, **max time**, and **now**:
+Get the current date/time:
 ```kt
-LocalTime.MIN
-LocalTime.MAX
-
 LocalDateTime.now()
 LocalDate.now()
 LocalTime.now()
 ```
 
-** Note: `MAX` and `atEndOfDay()` value is inspired by what [java.datetime used to use](https://cs.android.com/android/platform/superproject/+/master:libcore/ojluni/src/main/java/java/time/LocalTime.java;drc=63ed7b354cbcc49d2f05037026921b59be49d342;l=128)
+Get minimum/maximum time:
+```kt
+LocalTime.MIN
+LocalTime.MAX
+```
 
-You can also get `Duration` between 2 `LocalDateTime` objects by using the infix function `durationUntil`
+Get the `Duration` between two `LocalDateTime` objects using the `durationUntil` infix function:
 ```kt
 firstLocalDateTime durationUntil secondLocalDateTime
 ```
 
-More examples can be found in the [UnitTests directory](https://github.com/RaedGhazal/kotlinx-datetime-ext/tree/main/shared/src/commonTest/kotlin/com/raedghazal/kotlinx_datetime_ext)
+More examples can be found in the [unit tests directory](https://github.com/RaedGhazal/kotlinx-datetime-ext/tree/main/shared/src/commonTest/kotlin/com/raedghazal/kotlinx_datetime_ext).
 
 ---
 Thank you for using the library, contributions are welcomed!  
-support me by a star-ing the repo and follow me on social media ❤️
+Support me by a starring the repo and follow me on social media ❤️
 
 [LinkedIn](https://www.linkedin.com/in/raed-o-ghazal/) • [Twitter](https://twitter.com/RaedOGhazal) • [Github](https://github.com/RaedGhazal)


### PR DESCRIPTION
Small changes to the README here and there, including grammar corrections, using more concise wording, and proper punctuation.

Notably, I replaced `java.datetime` with `java.time`, the actual name of the Java APIs.

I also removed the note about `atEndOfDay()`, since the linked `java.time` code doesn't have such a function (it's a neat addition though!), and `MIN`/`MAX` exist in current `java.time` APIs.
It's already clear that the utility functions are heavily inspired by the original Java APIs :D