### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,9 @@ updates:
         patterns:
           - "com.android*"
           - "androidx*"
+
+  - package-ecosystem: "npm"
+    directory: "/kotlin-js-store"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.kotlinx*"
+      android:
+        patterns:
+          - "com.android*"
+          - "androidx*"


### PR DESCRIPTION
Adding dependabot to avoid manually updating 3rd party libraries.

@RaedGhazal, post merging may you too kindly ensure under repo `Settings` -> `Advanced Security`, the following is enabled per [docs](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide#enabling-dependabot-for-your-repository):

<img width="1200" src="https://github.com/user-attachments/assets/54e245e7-d5f0-4e89-8dad-887b09559c49" />

