### PR TITLE
Creates release notes via Github's Release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: ✨ Enhancements
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 🔨 Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
When creating release notes, you may auto-generate them using Github's `release.yml` specs. 

Auto-groups dependabot PRs under `🔨 Dependencies`, while others placed under `✨ Enhancements`, with just a click:

<img width="478" height="208" alt="Screenshot 2026-07-05 at 16 45 33" src="https://github.com/user-attachments/assets/b1183d2e-8fbf-470a-a67c-655182fd3a64" />

See [documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) for more.